### PR TITLE
Fix: use react-query to manage accounts data

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
   },
   "extends": ["airbnb", "plugin:import/recommended", "plugin:@typescript-eslint/recommended", "prettier"],
   "rules": {
+    "camelcase": "off",
     "comma-dangle": "off", // trailing comma 생략 가능
     "consistent-return": "off", // 함수에 return문 생략 가능
     "func-names": "off", // 익명 함수 사용 가능

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.0",
         "@tanstack/react-query": "^4.15.0",
+        "@tanstack/react-query-devtools": "^4.16.1",
         "@types/node": "18.11.9",
         "@types/react": "18.0.25",
         "@types/react-dom": "18.0.8",
@@ -726,21 +727,36 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.1.1.tgz",
+      "integrity": "sha512-IdmEekEYxQsoLOR0XQyw3jD1GujBpRRYaGJYQUw1eOT1eUugWxdc7jomh1VQ1EKHcdwDLpLaCz/8y4KraU4T9A==",
+      "dependencies": {
+        "remove-accents": "0.4.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kentcdodds"
+      }
+    },
     "node_modules/@tanstack/query-core": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.15.0.tgz",
-      "integrity": "sha512-zEZ7AuQRb8Ts+WXw9TtGtqydxmcOSRsWkFYxxH8dykPcumsV49BcNDLhHtYqVGPQpMjqMS4RoVYQP+budT6WbA==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.15.1.tgz",
+      "integrity": "sha512-+UfqJsNbPIVo0a9ANW0ZxtjiMfGLaaoIaL9vZeVycvmBuWywJGtSi7fgPVMCPdZQFOzMsaXaOsDtSKQD5xLRVQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.15.0.tgz",
-      "integrity": "sha512-WQZCSxZgYGkQUx2TRiGVcfxh0dsrP1qU7IYK/kbY1QbcWF2cQJsj80owgjpXBCRSk/nxpZ6j65Xi8TB5OTT5Vw==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.16.1.tgz",
+      "integrity": "sha512-PDE9u49wSDykPazlCoLFevUpceLjQ0Mm8i6038HgtTEKb/aoVnUZdlUP7C392ds3Cd75+EGlHU7qpEX06R7d9Q==",
       "dependencies": {
-        "@tanstack/query-core": "4.15.0",
+        "@tanstack/query-core": "4.15.1",
         "use-sync-external-store": "^1.2.0"
       },
       "funding": {
@@ -759,6 +775,33 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.16.1.tgz",
+      "integrity": "sha512-VrDYLmG+OOcvGSZL5avG4R8jhqeMFP7pzW2sh2BWEV9UfI+aocG+CW8y8ygacxuKy48m8Tyo/xfe8H1z9BGb+g==",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "8.1.1",
+        "superjson": "^1.10.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "4.16.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools/node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@tanstack/react-query/node_modules/use-sync-external-store": {
@@ -1635,6 +1678,20 @@
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.2.tgz",
+      "integrity": "sha512-CzATjGXzUQ0EvuvgOCI6A4BGOo2bcVx8B+eC2nF862iv9fopnPQwlrbACakNCHRIJbCSBj+J/9JeDf60k64MkA==",
+      "dependencies": {
+        "is-what": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/core-js-pure": {
       "version": "3.26.0",
@@ -3209,6 +3266,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.7.tgz",
+      "integrity": "sha512-DBVOQNiPKnGMxRMLIYSwERAS5MVY1B7xYiGnpgctsOFvVDz9f9PFXXxMcTOHuoqYp4NK9qFYQaIC1NRRxLMpBQ==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -4464,6 +4532,11 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/reselect": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
@@ -4917,6 +4990,17 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/superjson": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.11.0.tgz",
+      "integrity": "sha512-6PfAg1FKhqkwWvPb2uXhH4MkMttdc17eJ91+Aoz4s1XUEDZFmLfFx/xVA3wgkPxAGy5dpozgGdK6V/n20Wj9yg==",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/supports-color": {
@@ -5744,17 +5828,43 @@
         "tslib": "^2.4.0"
       }
     },
+    "@tanstack/match-sorter-utils": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.1.1.tgz",
+      "integrity": "sha512-IdmEekEYxQsoLOR0XQyw3jD1GujBpRRYaGJYQUw1eOT1eUugWxdc7jomh1VQ1EKHcdwDLpLaCz/8y4KraU4T9A==",
+      "requires": {
+        "remove-accents": "0.4.2"
+      }
+    },
     "@tanstack/query-core": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.15.0.tgz",
-      "integrity": "sha512-zEZ7AuQRb8Ts+WXw9TtGtqydxmcOSRsWkFYxxH8dykPcumsV49BcNDLhHtYqVGPQpMjqMS4RoVYQP+budT6WbA=="
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.15.1.tgz",
+      "integrity": "sha512-+UfqJsNbPIVo0a9ANW0ZxtjiMfGLaaoIaL9vZeVycvmBuWywJGtSi7fgPVMCPdZQFOzMsaXaOsDtSKQD5xLRVQ=="
     },
     "@tanstack/react-query": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.15.0.tgz",
-      "integrity": "sha512-WQZCSxZgYGkQUx2TRiGVcfxh0dsrP1qU7IYK/kbY1QbcWF2cQJsj80owgjpXBCRSk/nxpZ6j65Xi8TB5OTT5Vw==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.16.1.tgz",
+      "integrity": "sha512-PDE9u49wSDykPazlCoLFevUpceLjQ0Mm8i6038HgtTEKb/aoVnUZdlUP7C392ds3Cd75+EGlHU7qpEX06R7d9Q==",
       "requires": {
-        "@tanstack/query-core": "4.15.0",
+        "@tanstack/query-core": "4.15.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "dependencies": {
+        "use-sync-external-store": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+          "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+          "requires": {}
+        }
+      }
+    },
+    "@tanstack/react-query-devtools": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.16.1.tgz",
+      "integrity": "sha512-VrDYLmG+OOcvGSZL5avG4R8jhqeMFP7pzW2sh2BWEV9UfI+aocG+CW8y8ygacxuKy48m8Tyo/xfe8H1z9BGb+g==",
+      "requires": {
+        "@tanstack/match-sorter-utils": "8.1.1",
+        "superjson": "^1.10.0",
         "use-sync-external-store": "^1.2.0"
       },
       "dependencies": {
@@ -6360,6 +6470,14 @@
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
+    },
+    "copy-anything": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.2.tgz",
+      "integrity": "sha512-CzATjGXzUQ0EvuvgOCI6A4BGOo2bcVx8B+eC2nF862iv9fopnPQwlrbACakNCHRIJbCSBj+J/9JeDf60k64MkA==",
+      "requires": {
+        "is-what": "^4.1.6"
+      }
     },
     "core-js-pure": {
       "version": "3.26.0",
@@ -7455,6 +7573,11 @@
         "call-bind": "^1.0.2"
       }
     },
+    "is-what": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.7.tgz",
+      "integrity": "sha512-DBVOQNiPKnGMxRMLIYSwERAS5MVY1B7xYiGnpgctsOFvVDz9f9PFXXxMcTOHuoqYp4NK9qFYQaIC1NRRxLMpBQ=="
+    },
     "is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -8292,6 +8415,11 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
     },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "reselect": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
@@ -8593,6 +8721,14 @@
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
       "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
       "requires": {}
+    },
+    "superjson": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.11.0.tgz",
+      "integrity": "sha512-6PfAg1FKhqkwWvPb2uXhH4MkMttdc17eJ91+Aoz4s1XUEDZFmLfFx/xVA3wgkPxAGy5dpozgGdK6V/n20Wj9yg==",
+      "requires": {
+        "copy-anything": "^3.0.2"
+      }
     },
     "supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.0",
     "@tanstack/react-query": "^4.15.0",
+    "@tanstack/react-query-devtools": "^4.16.1",
     "@types/node": "18.11.9",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.8",

--- a/src/components/Accounts/index.tsx
+++ b/src/components/Accounts/index.tsx
@@ -1,25 +1,22 @@
 import { Account } from '@type/account';
 import useAccounts from '@hooks/useAccounts';
-import useAccountQueryDispatch from '@hooks/useAccountQueryDispatch';
-import useAccountQueryState from '@hooks/useAccountQueryState';
 import Seo from '@components/Layout/Seo';
 import Table from './Table';
 import Pagenation from './Pagenation';
 
 type Props = {
   accounts: Account[];
+  initialQuery: Record<string, unknown>;
 };
 
-function Accounts({ accounts }: Props) {
-  const { page, limit } = useAccountQueryState();
-  const { dispatchPage } = useAccountQueryDispatch();
-  useAccounts();
+function Accounts({ accounts, initialQuery }: Props) {
+  const { page, limit, dispatchPage, data } = useAccounts(accounts, initialQuery);
 
   return (
     <>
       <Seo title="D. PREFACE | 계좌 목록" />
-      <Table accounts={accounts} isSelectBox />
-      <Pagenation contents={accounts} page={page} limit={limit} dispatchPage={dispatchPage} />
+      <Table accounts={data} isSelectBox />
+      <Pagenation contents={data} page={page} limit={limit} dispatchPage={dispatchPage} />
     </>
   );
 }

--- a/src/hooks/useAccountQueryDispatch.ts
+++ b/src/hooks/useAccountQueryDispatch.ts
@@ -1,26 +1,36 @@
 import { useDispatch } from 'react-redux';
-import { setBrokerId, setIsActive, setPage, setStatus } from '@store/accountQuerySlice';
+import { setBrokerId, setIsActive, setLimit, setPage, setStatus } from '@store/accountQuerySlice';
+import setQueryParams from '@utils/setQueryParams';
 
 function useAccountQueryDispatch() {
   const dispatch = useDispatch();
 
   const dispatchBrokerId = (brokerId: string) => {
     dispatch(setBrokerId(brokerId));
+    setQueryParams({ broker_id: brokerId });
   };
 
   const dispatchStatus = (status: string) => {
     dispatch(setStatus(status));
+    setQueryParams({ status });
   };
 
   const dispatchActivity = (isActive: string) => {
     dispatch(setIsActive(isActive));
+    setQueryParams({ is_active: isActive });
   };
 
   const dispatchPage = (page: number) => {
     dispatch(setPage(page));
+    setQueryParams({ page });
   };
 
-  return { dispatchBrokerId, dispatchStatus, dispatchActivity, dispatchPage };
+  const dispatchLimit = (limit: number) => {
+    dispatch(setLimit(limit));
+    setQueryParams({ limit });
+  };
+
+  return { dispatchBrokerId, dispatchStatus, dispatchActivity, dispatchPage, dispatchLimit };
 }
 
 export default useAccountQueryDispatch;

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -1,21 +1,40 @@
 import { useEffect } from 'react';
-import { useRouter } from 'next/router';
+import { useQuery } from '@tanstack/react-query';
 
+import type { Account } from '@type/account';
+import AccountsService from '@services/AccountService';
 import useHeaderTitleDispatch from './useHeaderTitleDispatch';
-import useAccountURL from './useAccountURL';
+import useAccountQueryState from './useAccountQueryState';
+import useAccountQueryDispatch from './useAccountQueryDispatch';
 
-function useAccounts() {
-  const accountURL = useAccountURL();
-  const router = useRouter();
+function useAccounts(accounts: Account[], initialQuery: Record<string, unknown>) {
+  const accountQuery: Record<string, unknown> = useAccountQueryState();
+  const { dispatchPage, dispatchLimit, dispatchBrokerId, dispatchStatus, dispatchActivity } = useAccountQueryDispatch();
   const dispatchTitle = useHeaderTitleDispatch();
 
-  useEffect(() => {
-    router.push(accountURL);
-  }, [accountURL]);
+  const { data } = useQuery(['accounts', accountQuery], () => AccountsService.getAccounts(accountQuery), {
+    ...AccountsService.accountsQueryOptions,
+    initialData:
+      Object.keys(accountQuery) === Object.keys(initialQuery) &&
+      Object.keys(accountQuery).every((key) => accountQuery[key] === initialQuery[key])
+        ? accounts
+        : undefined,
+  });
 
   useEffect(() => {
     dispatchTitle('계좌 목록');
   }, []);
+
+  useEffect(() => {
+    const { page = 1, limit = 30, broker_id = 'all', status = 'all', is_active = 'all' } = initialQuery;
+    dispatchPage(Number(page));
+    dispatchLimit(Number(limit));
+    dispatchBrokerId(String(broker_id));
+    dispatchStatus(String(status));
+    dispatchActivity(String(is_active));
+  }, [initialQuery]);
+
+  return { page: Number(accountQuery.page), limit: Number(accountQuery.limit), dispatchPage, data: data ?? [] };
 }
 
 export default useAccounts;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import GlobalStyle from '@styles/GlobalStyles';
 import { colors } from '@styles/theme';
 import Layout from '@components/Layout';
 import store, { persistor } from '@store/index';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const queryClient = new QueryClient();
 
@@ -25,6 +26,7 @@ function App({ Component, pageProps }: AppProps) {
           </PersistGate>
         </Provider>
       </ThemeProvider>
+      <ReactQueryDevtools />
     </QueryClientProvider>
   );
 }

--- a/src/services/AccountService.ts
+++ b/src/services/AccountService.ts
@@ -1,9 +1,32 @@
 import axios from '@utils/getAxios';
 import { Account } from '@type/account';
+import getQueryString from '@utils/getQueryString';
 
 const AccountsService = {
-  async getAccounts() {
-    const res = await axios({ bearer: true }).get<Account[]>('/accounts');
+  accountsQueryOptions: {
+    staleTime: 3 * 60 * 1000,
+    keepPreviousData: true,
+  },
+
+  accountsQueryConverter(key: string) {
+    switch (key) {
+      case 'page':
+        return '_page';
+      case 'limit':
+        return '_limit';
+      case 'brokerId':
+        return 'broker_id';
+      case 'isActive':
+        return 'is_active';
+      default:
+        return key;
+    }
+  },
+
+  async getAccounts(params: Record<string, unknown>) {
+    const res = await axios({ bearer: true }).get<Account[]>(
+      `/accounts?${getQueryString(params, this.accountsQueryConverter)}`
+    );
     return res.data;
   },
 

--- a/src/store/accountQuerySlice.ts
+++ b/src/store/accountQuerySlice.ts
@@ -23,6 +23,9 @@ export const accountQuerySlice = createSlice({
     setPage: (state, action: { payload: number }) => {
       state.page = action.payload;
     },
+    setLimit: (state, action: { payload: number }) => {
+      state.limit = action.payload;
+    },
     setIsActive: (state, action: { payload: string }) => {
       if (action.payload === 'all') state.is_active = null;
       else state.is_active = action.payload;
@@ -41,4 +44,4 @@ export const accountQuerySlice = createSlice({
   },
 });
 
-export const { setPage, setIsActive, setBrokerId, setStatus } = accountQuerySlice.actions;
+export const { setPage, setLimit, setIsActive, setBrokerId, setStatus } = accountQuerySlice.actions;

--- a/src/utils/getQueryObject.ts
+++ b/src/utils/getQueryObject.ts
@@ -1,0 +1,9 @@
+const getQueryObject = (queryString: string) =>
+  Object.fromEntries(
+    queryString
+      .replaceAll('?', '')
+      .split('&')
+      .map((str) => str.split('='))
+  );
+
+export default getQueryObject;

--- a/src/utils/getQueryString.ts
+++ b/src/utils/getQueryString.ts
@@ -1,0 +1,7 @@
+const getQueryString = (query: Record<string, unknown>, converter?: (key: string) => string) =>
+  Object.entries(query)
+    .filter(([, value]) => value && value !== 'all')
+    .map(([key, value]) => `${converter ? converter(key) : key}=${value}`)
+    .join('&');
+
+export default getQueryString;

--- a/src/utils/setQueryParams.ts
+++ b/src/utils/setQueryParams.ts
@@ -1,0 +1,10 @@
+import getQueryObject from './getQueryObject';
+import getQueryString from './getQueryString';
+
+const setQueryParams = (params: Record<string, string | number | boolean>) => {
+  const prevParams = window.location.search ? getQueryObject(window.location.search) : {};
+  const url = `${window.location.pathname}?${getQueryString({ ...prevParams, ...params })}`;
+  window.history.replaceState({ ...window.history.state, as: url, url }, '', url);
+};
+
+export default setQueryParams;


### PR DESCRIPTION
최초 1회만 SSR 실행 후 필터/페이지 변경시 클라이언트에서 API 호출하도록 변경
(일단 accounts에만 적용, 필터/페이지변경/검색은 아직 develop보다 이전 브랜치이므로 적용 X)